### PR TITLE
feat: use cf for issuer

### DIFF
--- a/src/ApiStack.ts
+++ b/src/ApiStack.ts
@@ -138,6 +138,8 @@ export class ApiStack extends Stack {
     const yiviApiHost = SSM.StringParameter.fromStringParameterName(this, 'yivi-api-host', Statics.ssmYiviApiHost);
     const yiviApiRegion = SSM.StringParameter.fromStringParameterName(this, 'yivi-api-region', Statics.ssmYiviApiRegion);
     const brpApiUrl = SSM.StringParameter.fromStringParameterName(this, 'brp-api-url', Statics.ssmBrpApiEndpointUrl);
+
+
     const issueFunction = new ApiFunction(this, 'yivi-issue-issue-function', {
       table: this.sessionsTable,
       tablePermissions: 'ReadWrite',
@@ -148,7 +150,7 @@ export class ApiStack extends Stack {
         MTLS_CLIENT_CERT_NAME: Statics.ssmMTLSClientCert,
         MTLS_ROOT_CA_NAME: Statics.ssmMTLSRootCA,
         BRP_API_URL: Statics.ssmBrpApiEndpointUrl,
-        YIVI_API_HOST: Statics.ssmYiviApiHost,
+        YIVI_API_HOST: `${baseUrl}issue`,
         YIVI_API_REGION: Statics.ssmYiviApiRegion,
         YIVI_API_DEMO: props.configuration.useDemoScheme ? 'demo' : '',
         YIVI_API_ACCESS_KEY_ID_ARN: secretYiviApiAccessKeyId.secretArn,


### PR DESCRIPTION
Use cloudfront for yivi issuer api, so we can
use the cloudfront error responses.

Required for #564