### PR TITLE
feat: stats as table

### DIFF
--- a/src/app/static-resources/static/scripts/statistics.js
+++ b/src/app/static-resources/static/scripts/statistics.js
@@ -26,6 +26,20 @@ const chart = new Chart(ctx, {
   },
 });
 
+const table = document.getElementById('statistics-table');
+
+function updateTable(data) {
+  let body = '<tbody>';
+  for(let dataPoint of Object.keys(data).reverse()) {
+    body += `<tr>
+      <td>${dataPoint}</td><td>${data[dataPoint]}</td>
+    </tr>`;
+  }
+  body += '</tbody>';
+  const newBody = htmlStringToElement(body);
+  const oldBody = table.querySelector('tbody');
+  oldBody.replaceWith(newBody);
+}
 
 // Plot data on page load
 plotData();
@@ -37,7 +51,20 @@ function plotData(){
   
   // Fetch data from the same lambda as renders this page
   fetch(window.location.href + "?scope="+scope).then(response => {
-    response.json().then(data => {
+      data = {
+        "2024-04": 17,
+        "2024-03": 8,
+        "2024-02": 5,
+        "2024-01": 5,
+        "2023-12": 3,
+        "2023-11": 1,
+        "2023-10": 9,
+        "2023-09": 7,
+        "2023-08": 6,
+        "2023-07": 13,
+        "2023-06": 1,
+        "2023-05": 3
+    }
       const labels = Object.keys(data).reverse();
       const values = Object.values(data).reverse();
       console.log(data);
@@ -48,9 +75,21 @@ function plotData(){
       });
       console.log('Updating chart...');
       chart.update();
+      updateTable(data);
     });
-  }).catch(error => {
-    console.error(error);
-  });
 
+}
+
+
+/**
+ * Transform an html-string to an actual nodetree
+ * 
+ * @param {string} html the valid HTML as as string
+ * @returns {Node} the html node
+ */
+function htmlStringToElement(html) {
+  var template = document.createElement('template');
+  html = html.trim(); // Never return a text node of whitespace as the result
+  template.innerHTML = html;
+  return template.content.firstChild;
 }

--- a/src/app/static-resources/static/scripts/statistics.js
+++ b/src/app/static-resources/static/scripts/statistics.js
@@ -51,20 +51,7 @@ function plotData(){
   
   // Fetch data from the same lambda as renders this page
   fetch(window.location.href + "?scope="+scope).then(response => {
-      data = {
-        "2024-04": 17,
-        "2024-03": 8,
-        "2024-02": 5,
-        "2024-01": 5,
-        "2023-12": 3,
-        "2023-11": 1,
-        "2023-10": 9,
-        "2023-09": 7,
-        "2023-08": 6,
-        "2023-07": 13,
-        "2023-06": 1,
-        "2023-05": 3
-    }
+    response.json().then(data => {
       const labels = Object.keys(data).reverse();
       const values = Object.values(data).reverse();
       console.log(data);
@@ -77,9 +64,9 @@ function plotData(){
       chart.update();
       updateTable(data);
     });
-
-}
-
+  }).catch(error => {
+    console.error(error);
+  });
 
 /**
  * Transform an html-string to an actual nodetree

--- a/src/app/static-resources/static/styles/main.css
+++ b/src/app/static-resources/static/styles/main.css
@@ -141,3 +141,11 @@ img {
 .hidden {
   display: none;
 }
+
+table th {
+  font-weight: bold;
+}
+
+table th, td {
+  padding: .25em;
+}

--- a/src/app/statistics/statistics.mustache
+++ b/src/app/statistics/statistics.mustache
@@ -11,6 +11,17 @@
         <option value="year">Per jaar</option>
     </select>
     <canvas id="chart"></canvas>
+    <table class="responsive-table" id="statistics-table">
+      <thead>
+        <tr>
+          <th>Periode</th>
+          <th>Aantal</th>
+        </tr>
+        </thead>
+        <tbody>
+            <tr><td colspan="2">Nog geen data geladen</td></tr>
+        </tbody>
+    </table>
 </main>
 
 <script src="/static/scripts/chart.umd.js"></script>


### PR DESCRIPTION
The canvas-based chart is inaccessible to screen
readers etc.. This adds the same data as a table,
to provide a text-based alternative.