### PR TITLE
feat: sd-jwt docs and brp warnings

### DIFF
--- a/docs/SD-JWT/SD-JWT.md
+++ b/docs/SD-JWT/SD-JWT.md
@@ -31,7 +31,7 @@ Voorbeeld acceptatie:
 $ AP_JSON_FILE=app.json ISSUER_HOST=issue.yivi-brp-accp.csp-nijmegen.nl C=NL ST=Gelderland L=Nijmegen O="Gemeente Nijmegen" bash gen.sh
 ```
 
-De .key bestanden worden opgeslagen in Bitwarden en lokaal verwijderd. Ook de CSR kan weg nadat de certificaten binnen zijn.
+De .key bestanden worden opgeslagen in AWS Secrets Manager en lokaal verwijderd. Ook de CSR kan weg nadat de certificaten binnen zijn.
 
 ## Yivi Server
 

--- a/docs/SD-JWT/SD-JWT.md
+++ b/docs/SD-JWT/SD-JWT.md
@@ -34,6 +34,16 @@ $ AP_JSON_FILE=app.json ISSUER_HOST=issue.yivi-brp-accp.csp-nijmegen.nl C=NL ST=
 De .key bestanden worden opgeslagen in Bitwarden en lokaal verwijderd. Ook de CSR kan weg nadat de certificaten binnen zijn.
 
 ## Yivi Server
-De overgang naar SD-JWT VC betekent ook wijzigingen in de Yivi server.
 
-TODO
+De overgang naar SD-JWT VC betekent ook wijzigingen in de Yivi server. Zonder correcte configuratie aan de server kant zal het `sdJwtBatchSize` veld in de issuance request genegeerd worden en worden er alleen Idemix credentials uitgegeven.
+
+### Vereisten
+
+1. **irmago versie ≥ 0.19** Oudere versies ondersteunen geen SD-JWT VC issuance.
+2. **Issuer certificaat** Het SD-JWT VC issuer certificaat moet beschikbaar zijn in een `certs` directory, met een bestandsnaam die overeenkomt met de issuer identifier uit het scheme (bijv. `pbdf.gemeente.pem`).
+3. **Private key** De bijbehorende private key moet in een aparte `privkeys` directory staan (bijv. `pbdf.gemeente.pem`).
+4. **Server configuratie** De paden naar de `certs` en `privkeys` directories moeten geconfigureerd zijn op de IRMA server (via `config.json`, command line parameters, of environment variables).
+
+### Meer informatie
+
+De configuratie en deployment van de Yivi server zelf wordt beheerd in een aparte repository: https://github.com/GemeenteNijmegen/yivi-issue-server

--- a/src/app/issue/HaalCentraalBrpApi.ts
+++ b/src/app/issue/HaalCentraalBrpApi.ts
@@ -124,17 +124,22 @@ export class HaalCentraalBrpApi {
       const persoon = data.personen[0];
 
       if (persoon.overlijden?.datum) {
-        throw new Error('Persoon lijkt overleden');
+        console.warn('Persoon lijkt overleden');
+        return { error: 'Persoon lijkt overleden', warning: true };
       }
       if (persoon.opschortingBijhouding) {
         const code = persoon.opschortingBijhouding.reden.code;
         if (code == 'O') {
-          throw new Error('Persoon lijkt overleden');
+          console.warn('Persoon lijkt overleden');
+          return { error: 'Persoon lijkt overleden', warning: true };
         }
-        throw new Error(`Bijhouding opgeschort met reden ${persoon.opschortingBijhouding.reden.code}`); // Zie https://developer.rvig.nl/lo-brp/LO-BRP/#e6720
+        const message = `Bijhouding opgeschort met reden ${persoon.opschortingBijhouding.reden.code}`; // Zie https://developer.rvig.nl/lo-brp/LO-BRP/#e6720
+        console.warn(message);
+        return { error: message, warning: true };
       }
       if (persoon.verblijfplaats?.type != 'Adres') {
-        throw new Error('Verblijfplaats is geen adres');
+        console.warn('Verblijfplaats is geen adres');
+        return { error: 'Verblijfplaats is geen adres', warning: true };
       }
 
       return this.transformToInternalFormat(persoon, aBsn.bsn);


### PR DESCRIPTION
Fixes #1296

1. SD-JWT docs update

2. Warning in plaats van applicatie error bij BRP check:

Check op overlijden in de BRP (Basisregistratie Personen) API-response.

Wat het doet:

Als de persoon een overlijden.datum heeft in de BRP-gegevens, wordt de request vroegtijdig afgebroken.
Er wordt een warning gelogd naar de console ('Persoon lijkt overleden').
Het retourneert een object met { error: 'Persoon lijkt overleden', warning: true } dat signaleert aan de aanroepende code dat er geen credential/kaart uitgeleverd mag worden.
De reden is dat je geen Yivi-credential wilt uitgeven aan iemand die als overleden geregistreerd staat in de BRP. Het is een veiligheidscheck: als iemand het BSN van een overleden persoon zou gebruiken, wordt het issuen geblokkeerd.

Het `warning: true` veld onderscheidt dit van een technische fout, het is geen API-fout maar een bewuste afwijzing op basis van de data.